### PR TITLE
Change to Auto in comparatorMod

### DIFF
--- a/src/Anagram.cpp
+++ b/src/Anagram.cpp
@@ -22,7 +22,7 @@ namespace
         // sort will not compare things that only have one letter, but it still needs to be lowercase
         if ( word.size() == 1 ) return std::string { std::tolower ( word [0], loc ) };
 
-        const auto comparatorMod = [&loc] ( char& a, char& b ) {
+        const auto comparatorMod = [&loc] ( auto& a, auto& b ) {
             a = std::tolower ( a, loc );
             b = std::tolower ( b, loc );
 

--- a/tests/AnagramTest.cpp
+++ b/tests/AnagramTest.cpp
@@ -52,7 +52,6 @@ TEST ( AnagramTest, RepeatedLetterTest )
     result = anagram.lookup ( "A" );
     EXPECT_EQ ( result.size(), 1 );
     EXPECT_EQ ( result[0], "a" );
-
 }
 
 TEST ( AnagramTest, SubwordTest )
@@ -65,5 +64,19 @@ TEST ( AnagramTest, SubwordTest )
     auto result = anagram.lookup ( "act" );
     EXPECT_EQ ( result.size(), 1 );
     EXPECT_EQ ( result[0], "cat" );
+}
 
+TEST ( AnagramTest, NonEnglishCharactersTest )
+{
+    hemiola::Anagram anagram;
+
+    anagram.insert ( "actor" );
+    anagram.insert ( "cät" );
+
+    auto result = anagram.lookup ( "act" );
+    EXPECT_EQ ( result.size(), 0 );
+
+    result = anagram.lookup ( "äct" );
+    EXPECT_EQ ( result.size(), 1 );
+    EXPECT_EQ ( result[0], "cät" );
 }


### PR DESCRIPTION
Changed to `auto` in the `comparatorMod`, so that we are more likely to be able to deal with non-english characters.