### PR TITLE
wstring2string

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ To run hemiola one simply can execute the following command on your rpi:
 sudo ./hemiola/build/hemiola
 ```
 
-Currently logging is output to `/var/log/hemiola.log`
+Currently logging is output to `/var/log/hemiola/hemiola.log`

--- a/include/KeyTable.h
+++ b/include/KeyTable.h
@@ -48,28 +48,7 @@ namespace hemiola
          * @brief Update our keymaps based on the system keymapping
          * @post keymaps are updated to coincide with the system keymap
          */
-        void determineSystemKeymap();
-
-        /*!
-         * @brief check if code is a char
-         * @param code the scan code from key press
-         * @return true if code is a char
-         */
-        bool isCharKey ( unsigned int code ) const;
-
-        /*!
-         * @brief check if code is a function key
-         * @param code the scan code from key press
-         * @return true if code is a function key
-         */
-        bool isFuncKey ( unsigned int code ) const;
-
-        /*!
-         * @brief check if code is used
-         * @param code the scan code from key press
-         * @return true if code is used
-         */
-        inline bool isUsedKey ( unsigned int code ) const;
+        // void determineSystemKeymap();
 
         /*!
          * @brief convert a scan code to a character
@@ -77,15 +56,8 @@ namespace hemiola
          * @param keyState the current state of the keypress
          * @return character representation of key press or nullopt if no representation found
          */
-        // std::optional<wchar_t> handleScanCode ( unsigned int code, const KeyState& keyState )
+        // std::optional<char_t> handleScanCode ( unsigned int code, const KeyState& keyState )
         // const;
-
-        /*
-         * @brief check if the scan code is a valid scan code
-         * @param code the scan code from key press
-         * @return true if the code is valid
-         */
-        bool isCodeValid ( unsigned int code ) const { return code < m_CharOrFunc.size(); }
 
         /*!
          * @brief convert a scan code (keyboard position) to the corresponding hex value
@@ -113,101 +85,115 @@ namespace hemiola
         bool isModifier ( unsigned int code ) const { return ( m_ModiferHex.count ( code ) != 0 ); }
 
         /*!
-         * @brief determine if the scan code is a valid key non modifier key press represented in
-         *        our keytable
+         * @brief determine if the scan code is a character key
+         * @param code to check
+         * @return true if the scan code is a character key
+         */
+        bool isCharKey ( unsigned int code ) const { return m_HexValues.count ( code ) != 0; }
+
+        /*!
+         * @brief determine if the scan code is a valid key in our keytable
          * @param code to check
          * @return true if the scan code is a valid key
          */
-        bool isKeyValid ( unsigned int code ) const { return m_HexValues.count ( code ) != 0; }
+        bool isKeyValid ( unsigned int code ) const
+        {
+            return isCharKey ( code ) || isModifier ( code );
+        }
 
     private:
         /*!
-         * @brief get the lower case character corresponding to a scan code
+         * @brief get the lower case string corresponding to a scan code
          * @param code the scan code from key press
-         * @return character representing the scan code
+         * @return string representing the scan code or empty string if not a valid key code
          */
-        wchar_t charKeys ( unsigned int code ) const
-        {
-            return m_CharKeys [toCharKeysIndex ( code )];
-        }
+        std::string charKeys ( unsigned int code ) const;
 
         /*!
-         * @brief get the upper character corresponding to a scan code
+         * @brief get the modifier key string corresponding to a scan code
          * @param code the scan code from key press
-         * @return character representing the scan code
+         * @return function key representing the scan code or empty string if not a valid key code
          */
-        wchar_t shiftKeys ( unsigned int code ) const
-        {
-            return m_ShiftKeys [toCharKeysIndex ( code )];
-        }
+        std::string modKeys ( unsigned int code ) const;
+
+        std::unordered_map<int, std::string> m_CharKeys = {
+            { KEY_A, "a" },  // Keyboard a and A
+            { KEY_B, "b" },  // Keyboard b and B
+            { KEY_C, "c" },  // Keyboard c and C
+            { KEY_D, "d" },  // Keyboard d and D
+            { KEY_E, "e" },  // Keyboard e and E
+            { KEY_F, "f" },  // Keyboard f and F
+            { KEY_G, "g" },  // Keyboard g and G
+            { KEY_H, "h" },  // Keyboard h and H
+            { KEY_I, "i" },  // Keyboard i and I
+            { KEY_J, "j" },  // Keyboard j and J
+            { KEY_K, "k" },  // Keyboard k and K
+            { KEY_L, "l" },  // Keyboard l and L
+            { KEY_M, "m" },  // Keyboard m and M
+            { KEY_N, "n" },  // Keyboard n and N
+            { KEY_O, "o" },  // Keyboard o and O
+            { KEY_P, "p" },  // Keyboard p and P
+            { KEY_Q, "q" },  // Keyboard q and Q
+            { KEY_R, "r" },  // Keyboard r and R
+            { KEY_S, "s" },  // Keyboard s and S
+            { KEY_T, "t" },  // Keyboard t and T
+            { KEY_U, "u" },  // Keyboard u and U
+            { KEY_V, "v" },  // Keyboard v and V
+            { KEY_W, "w" },  // Keyboard w and W
+            { KEY_X, "x" },  // Keyboard x and X
+            { KEY_Y, "y" },  // Keyboard y and Y
+            { KEY_Z, "z" },  // Keyboard z and Z
+
+            { KEY_1, "1" },  // Keyboard 1 and !
+            { KEY_2, "2" },  // Keyboard 2 and @
+            { KEY_3, "3" },  // Keyboard 3 and #
+            { KEY_4, "4" },  // Keyboard 4 and $
+            { KEY_5, "5" },  // Keyboard 5 and %
+            { KEY_6, "6" },  // Keyboard 6 and ^
+            { KEY_7, "7" },  // Keyboard 7 and &
+            { KEY_8, "8" },  // Keyboard 8 and *
+            { KEY_9, "9" },  // Keyboard 9 and (
+            { KEY_0, "0" },  // Keyboard 0 and )
+
+            { KEY_ENTER, "<ENTER/>" },          // Keyboard Return (ENTER)
+            { KEY_ESC, "<ESC/>" },              // Keyboard ESCAPE
+            { KEY_BACKSPACE, "<BACKSPACE/>" },  // Keyboard DELETE (Backspace)
+            { KEY_TAB, "<TAB/>" },              // Keyboard Tab
+            { KEY_SPACE, "<SPACE/>" },          // Keyboard Spacebar
+            { KEY_MINUS, "-" },                 // Keyboard - and _
+            { KEY_EQUAL, "=" },                 // Keyboard = and +
+            { KEY_LEFTBRACE, "[" },             // Keyboard [ and {
+            { KEY_RIGHTBRACE, "]" },            // Keyboard ] and }
+            { KEY_BACKSLASH, "\\" },            // Keyboard \ and |
+            { KEY_SEMICOLON, ";" },             // Keyboard ; and :
+            { KEY_APOSTROPHE, "'" },            // Keyboard ' and "
+            { KEY_GRAVE, "`" },                 // Keyboard ` and ~
+            { KEY_COMMA, "," },                 // Keyboard , and <
+            { KEY_DOT, "." },                   // Keyboard . and >
+            { KEY_SLASH, "/" },                 // Keyboard / and ?
+            { KEY_CAPSLOCK, "<CAPSLOCK/>" },    // Keyboard Caps Lock
+
+            { KEY_DELETE, "<DELETE/>" },  // Keyboard Delete Forward
+        };
 
         /*!
-         * @brief get the altgr character corresponding to a scan code
-         * @param code the scan code from key press
-         * @return character representing the scan code
+         * @brief Function Keys these will have slightly different representation since
+         *        they have a begin and an end, e.g. <LCTRL></LCTRL>
          */
-        wchar_t altgrKeys ( unsigned int code ) const
-        {
-            return m_AltgrKeys [toCharKeysIndex ( code )];
-        }
+        std::unordered_map<int, std::string> m_ModKeys {
+            { KEY_LEFTCTRL, "LCTRL" },     // Keyboard Left Control
+            { KEY_LEFTSHIFT, "LSHIFT" },   // Keyboard Left Shift
+            { KEY_LEFTALT, "LALT" },       // Keyboard Left Alt
+            { KEY_LEFTMETA, "LMETA" },     // Keyboard Left GUI
+            { KEY_RIGHTCTRL, "RCTRL" },    // Keyboard Right Control
+            { KEY_RIGHTSHIFT, "RSHIFT" },  // Keyboard Right Shift
+            { KEY_RIGHTALT, "RALT" },      // Keyboard Right Alt
+            { KEY_RIGHTMETA, "RMETA" },    // Keyboard Right GUI
+        };
 
         /*!
-         * @brief get the function key character corresponding to a scan code
-         * @param code the scan code from key press
-         * @return function key character representing the scan code
+         * @brief map of key code to hex value for key reports
          */
-        std::wstring funcKeys ( unsigned int code ) const
-        {
-            return m_FuncKeys [toFuncKeysIndex ( code )];
-        }
-
-        /*!
-         * @brief translates character keycodes to continuous array indexes
-         * @param code the scan code from key press
-         * @return the index of character from the keymap
-         */
-        int toCharKeysIndex ( unsigned int keycode ) const;
-
-        /*!
-         * @brief translates function keys keycodes to continuous array indexes
-         * @param code the scan code from key press
-         * @return the index of function key from the keymap
-         */
-        int toFuncKeysIndex ( unsigned int keycode ) const;
-
-        // these are ordered default US keymap keys
-        /*!
-         * @brief US lower case key characters
-         */
-        std::wstring m_CharKeys { L"1234567890-=qwertyuiop[]asdfghjkl;'`\\zxcvbnm,./<" };
-        /*!
-         * @brief US upper case key characters
-         */
-        std::wstring m_ShiftKeys { L"!@#$%^&*()_+QWERTYUIOP{}ASDFGHJKL:\"~|ZXCVBNM<>?>" };
-        // TODO: add altgrShiftKeys[]
-        // (http://en.wikipedia.org/wiki/AltGr_key#US_international)
-        std::wstring m_AltgrKeys { 49, 0 };
-
-        /*!
-         * @brief Function Keys
-         */
-        const std::vector<std::wstring> m_FuncKeys
-            = { L"<Esc>",          L"<BckSp>", L"<Tab>",   L"<Enter>",
-                L"<LCtrl>",        L"<LShft>", L"<RShft>", L"<KP*>",
-                L"<LAlt>",         L" ",       L"<CpsLk>", L"<F1>",
-                L"<F2>",           L"<F3>",    L"<F4>",    L"<F5>",
-                L"<F6>",           L"<F7>",    L"<F8>",    L"<F9>",
-                L"<F10>",          L"<NumLk>", L"<ScrLk>", L"<KP7>",
-                L"<KP8>",          L"<KP9>",   L"<KP->",   L"<KP4>",
-                L"<KP5>",          L"<KP6>",   L"<KP+>",   L"<KP1>",
-                L"<KP2>",          L"<KP3>",   L"<KP0>",   L"<KP.>",
-                /*"<",*/ L"<F11>", L"<F12>",   L"<KPEnt>", L"<RCtrl>",
-                L"<KP/>",          L"<PrtSc>", L"<AltGr>", L"<Break>" /*linefeed?*/,
-                L"<Home>",         L"<Up>",    L"<PgUp>",  L"<Left>",
-                L"<Right>",        L"<End>",   L"<Down>",  L"<PgDn>",
-                L"<Ins>",          L"<Del>",   L"<Pause>", L"<LMeta>",
-                L"<RMeta>",        L"<Menu>" };
-
         // TODO: update this from key map
         std::unordered_map<int, uint8_t> m_HexValues = {
             /**
@@ -218,8 +204,9 @@ namespace hemiola
              * KEY_ERR_OVF in all slots to indicate this condition.
              */
 
-            // { KEY_NONE, 0x00 },     // No key pressed
-            // { KEY_ERR_OVF, 0x01 },  //  Keyboard Error Roll Over - used for all slots if too many
+            // { KEY_NONE, "NONE" },     // No key pressed
+            // { KEY_ERR_OVF, "ERR_OVF" },  //  Keyboard Error Roll Over - used for all slots if too
+            // many
             //  keys are pressed ("Phantom key")
             // 0x02 //  Keyboard POST Fail
             // 0x03 //  Keyboard Error Undefined
@@ -475,18 +462,6 @@ namespace hemiola
             { KEY_RIGHTALT, 0x40 },    // Keyboard Right Alt
             { KEY_RIGHTMETA, 0x80 },   // Keyboard Right GUI
         };
-
-        const std::string m_CharOrFunc
-            =  // c = character key, f = function key, _ = blank/error ('_' is used, don't change);
-               // all according to KEY_* defines from <linux/input.h>
-            "_fccccccccccccff"
-            "ccccccccccccffcc"
-            "ccccccccccfccccc"
-            "ccccccffffffffff"
-            "ffffffffffffffff"
-            "ffff__cff_______"
-            "ffffffffffffffff"
-            "_______f_____fff";
 
         unsigned short N_KEYS_DEFINED = 106;  // sum of all 'c' and 'f' chars in charOrFunc[]
     };

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -25,40 +25,13 @@
 #include <memory>
 
 /*!
- * @brief enumerator defining log levels
+ * @brief macro defining logging. Use some preprocessor tricks to simply use INFO, DEBUG, etc.
+ *        and only expand the variadic portion if there are arguments.
  */
-enum
-{
-    INFO = 0,
-    ERROR,
-    WARN,
-    CRITICAL,
-    DEBUG,
-};
-
-/*!
- * @brief macro defining logging
- */
-#define LOG( LEVEL, ... )                     \
-    switch ( LEVEL ) {                        \
-        case ( INFO ):                        \
-            spdlog::info ( __VA_ARGS__ );     \
-            break;                            \
-        case ( ERROR ):                       \
-            spdlog::error ( __VA_ARGS__ );    \
-            break;                            \
-        case ( WARN ):                        \
-            spdlog::warn ( __VA_ARGS__ );     \
-            break;                            \
-        case ( CRITICAL ):                    \
-            spdlog::critical ( __VA_ARGS__ ); \
-            break;                            \
-        case ( DEBUG ):                       \
-            spdlog::debug ( __VA_ARGS__ );    \
-            break;                            \
-        default:                              \
-            break;                            \
-    }
+#define LOG( LEVEL, format, ... )                                                  \
+    spdlog::log ( static_cast<spdlog::level::level_enum> ( SPDLOG_LEVEL_##LEVEL ), \
+                  format,                                                          \
+                  ##__VA_ARGS__ );
 
 namespace hemiola
 {

--- a/src/KeyTable.cpp
+++ b/src/KeyTable.cpp
@@ -32,156 +32,111 @@
 
 using namespace hemiola;
 
-void hemiola::KeyTable::determineSystemKeymap()
+// void hemiola::KeyTable::determineSystemKeymap()
+// {
+//     // custom map will be used; erase existing US keymapping
+//     m_CharKeys.clear();
+//     m_ShiftKeys.clear();
+//     m_AltgrKeys.clear();
+
+//     m_CharKeys.resize ( 49 );
+//     m_ShiftKeys.resize ( 49 );
+//     m_AltgrKeys.resize ( 49 );
+
+//     // get keymap from dumpkeys
+//     // if one knows of a better, more portable way to get char-s from symbolic keysym-s from
+//     // `dumpkeys` or `xmodmap` or another, PLEASE LET ME KNOW! kthx
+//     std::stringstream ss,
+//         dump (
+//             execute ( COMMAND_STR_DUMPKEYS ) );  // see example output after i.e. `loadkeys
+//             slovene`
+//     std::string line;
+
+//     unsigned int i = 0;  // code
+//     int index;
+//     int utf8code;  // utf-8 code of keysym answering code i
+
+//     while ( std::getline ( dump, line ) ) {
+//         ss.clear();
+//         ss.str ( "" );
+//         utf8code = 0;
+
+//         // replace any U+#### with 0x#### for easier parsing
+//         index = line.find ( "U+", 0 );
+//         while ( static_cast<std::string::size_type> ( index ) != std::string::npos ) {
+//             line [index] = '0';
+//             line [index + 1] = 'x';
+//             index = line.find ( "U+", index );
+//         }
+
+//         if ( !isCodeValid ( ++i ) )
+//             break;  // only ever map codes up to 128 (currently N_KEYS_DEFINED are used)
+//         if ( !isCharKey ( i ) )
+//             continue;  // only map character keys of keyboard
+
+//         assert ( line.size() > 0 );
+//         if ( line [0] == 'k' ) {  // if line starts with 'code'
+//             index = toCharKeysIndex ( i );
+
+//             ss << &line [14];  // 1st keysym starts at index 14 (skip "code XXX = ")
+//             ss >> std::hex >> utf8code;
+//             // 0XB00CLUELESS: 0xB00 is added to some keysyms that are preceeded with '+'; I
+//             // don't really know why; see `man keymaps`; `man loadkeys` says numeric keysym
+//             // values aren't to be relied on, orly?
+//             if ( line [14] == '+' && ( utf8code & 0xB00 ) )
+//                 utf8code ^= 0xB00;
+//             m_CharKeys [index] = static_cast<char> ( utf8code );
+
+//             // if there is a second keysym column, assume it is a shift column
+//             if ( ss >> std::hex >> utf8code ) {
+//                 if ( line [14] == '+' && ( utf8code & 0xB00 ) )
+//                     utf8code ^= 0xB00;
+//                 m_ShiftKeys [index] = static_cast<char> ( utf8code );
+//             }
+
+//             // if there is a third keysym column, assume it is an altgr column
+//             if ( ss >> std::hex >> utf8code ) {
+//                 if ( line [14] == '+' && ( utf8code & 0xB00 ) )
+//                     utf8code ^= 0xB00;
+//                 m_AltgrKeys [index] = static_cast<char> ( utf8code );
+//             }
+
+//             continue;
+//         }
+
+//         // else if line starts with 'shift i'
+//         index = toCharKeysIndex ( --i );
+//         ss << &line [21];  // 1st keysym starts at index 21 (skip "\tshift\tcode XXX = " or
+//                            // "\taltgr\tcode XXX = ")
+//         ss >> std::hex >> utf8code;
+//         if ( line [21] == '+' && ( utf8code & 0xB00 ) )
+//             utf8code ^= 0xB00;  // see line 0XB00CLUELESS
+
+//         if ( line [1] == 's' )  // if line starts with "shift"
+//             m_ShiftKeys [index] = static_cast<char> ( utf8code );
+//         if ( line [1] == 'a' )  // if line starts with "altgr"
+//             m_AltgrKeys [index] = static_cast<char> ( utf8code );
+//     }  // while (getline(dump, line))
+// }
+
+std::string hemiola::KeyTable::charKeys ( unsigned int code ) const
 {
-    // custom map will be used; erase existing US keymapping
-    m_CharKeys.clear();
-    m_ShiftKeys.clear();
-    m_AltgrKeys.clear();
-
-    m_CharKeys.resize ( 49 );
-    m_ShiftKeys.resize ( 49 );
-    m_AltgrKeys.resize ( 49 );
-
-    // get keymap from dumpkeys
-    // if one knows of a better, more portable way to get wchar_t-s from symbolic keysym-s from
-    // `dumpkeys` or `xmodmap` or another, PLEASE LET ME KNOW! kthx
-    std::stringstream ss,
-        dump (
-            execute ( COMMAND_STR_DUMPKEYS ) );  // see example output after i.e. `loadkeys slovene`
-    std::string line;
-
-    unsigned int i = 0;  // code
-    int index;
-    int utf8code;  // utf-8 code of keysym answering code i
-
-    while ( std::getline ( dump, line ) ) {
-        ss.clear();
-        ss.str ( "" );
-        utf8code = 0;
-
-        // replace any U+#### with 0x#### for easier parsing
-        index = line.find ( "U+", 0 );
-        while ( static_cast<std::string::size_type> ( index ) != std::string::npos ) {
-            line [index] = '0';
-            line [index + 1] = 'x';
-            index = line.find ( "U+", index );
-        }
-
-        if ( !isCodeValid ( ++i ) )
-            break;  // only ever map codes up to 128 (currently N_KEYS_DEFINED are used)
-        if ( !isCharKey ( i ) )
-            continue;  // only map character keys of keyboard
-
-        assert ( line.size() > 0 );
-        if ( line [0] == 'k' ) {  // if line starts with 'code'
-            index = toCharKeysIndex ( i );
-
-            ss << &line [14];  // 1st keysym starts at index 14 (skip "code XXX = ")
-            ss >> std::hex >> utf8code;
-            // 0XB00CLUELESS: 0xB00 is added to some keysyms that are preceeded with '+'; I
-            // don't really know why; see `man keymaps`; `man loadkeys` says numeric keysym
-            // values aren't to be relied on, orly?
-            if ( line [14] == '+' && ( utf8code & 0xB00 ) )
-                utf8code ^= 0xB00;
-            m_CharKeys [index] = static_cast<wchar_t> ( utf8code );
-
-            // if there is a second keysym column, assume it is a shift column
-            if ( ss >> std::hex >> utf8code ) {
-                if ( line [14] == '+' && ( utf8code & 0xB00 ) )
-                    utf8code ^= 0xB00;
-                m_ShiftKeys [index] = static_cast<wchar_t> ( utf8code );
-            }
-
-            // if there is a third keysym column, assume it is an altgr column
-            if ( ss >> std::hex >> utf8code ) {
-                if ( line [14] == '+' && ( utf8code & 0xB00 ) )
-                    utf8code ^= 0xB00;
-                m_AltgrKeys [index] = static_cast<wchar_t> ( utf8code );
-            }
-
-            continue;
-        }
-
-        // else if line starts with 'shift i'
-        index = toCharKeysIndex ( --i );
-        ss << &line [21];  // 1st keysym starts at index 21 (skip "\tshift\tcode XXX = " or
-                           // "\taltgr\tcode XXX = ")
-        ss >> std::hex >> utf8code;
-        if ( line [21] == '+' && ( utf8code & 0xB00 ) )
-            utf8code ^= 0xB00;  // see line 0XB00CLUELESS
-
-        if ( line [1] == 's' )  // if line starts with "shift"
-            m_ShiftKeys [index] = static_cast<wchar_t> ( utf8code );
-        if ( line [1] == 'a' )  // if line starts with "altgr"
-            m_AltgrKeys [index] = static_cast<wchar_t> ( utf8code );
-    }  // while (getline(dump, line))
-}
-
-bool hemiola::KeyTable::isCharKey ( unsigned int code ) const
-{
-    if ( code > m_CharOrFunc.size() ) {
-        return false;
+    try {
+        return m_CharKeys.at ( code );
+    } catch ( ... ) {
+        LOG ( ERROR, "Invalid character key code: {}", code );
+        return "";
     }
-    return ( m_CharOrFunc [code] == 'c' );
 }
 
-bool hemiola::KeyTable::isFuncKey ( unsigned int code ) const
+std::string hemiola::KeyTable::modKeys ( unsigned int code ) const
 {
-    if ( code > m_CharOrFunc.size() ) {
-        return false;
+    try {
+        return m_ModKeys.at ( code );
+    } catch ( ... ) {
+        LOG ( ERROR, "Invalid modifier key code: {}", code );
+        return "";
     }
-    return ( m_CharOrFunc [code] == 'f' );
-}
-
-bool hemiola::KeyTable::isUsedKey ( unsigned int code ) const
-{
-    if ( code > m_CharOrFunc.size() ) {
-        return false;
-    }
-    return ( m_CharOrFunc [code] != '_' );
-}
-
-int hemiola::KeyTable::toCharKeysIndex ( unsigned int code ) const
-{
-    int index = -1;                            // not character code
-    if ( code >= KEY_1 && code <= KEY_EQUAL )  // codes 2-13: US keyboard: 1, 2, ..., 0, -, =
-        index = code - 2;
-    if ( code >= KEY_Q && code <= KEY_RIGHTBRACE )  // codes 16-27: q, w, ..., [, ]
-        index = code - 4;
-    if ( code >= KEY_A && code <= KEY_GRAVE )  // codes 30-41: a, s, ..., ', `
-        index = code - 6;
-    if ( code >= KEY_BACKSLASH && code <= KEY_SLASH )  // codes 43-53: \, z, ..., ., /
-        index = code - 7;
-
-    if ( code == KEY_102ND )
-        index = 47;  // key right to the left of 'Z' on US layout
-
-    return index;
-}
-
-inline int hemiola::KeyTable::toFuncKeysIndex ( unsigned int code ) const
-{
-    int index = -1;         // not character code
-    if ( code == KEY_ESC )  // 1
-        index = 0;
-    if ( code >= KEY_BACKSPACE && code <= KEY_TAB )  // 14-15
-        index = code - 13;
-    if ( code >= KEY_ENTER && code <= KEY_LEFTCTRL )  // 28-29
-        index = code - 25;
-    if ( code == KEY_LEFTSHIFT )
-        index = code - 37;                              // 42
-    if ( code >= KEY_RIGHTSHIFT && code <= KEY_KPDOT )  // 54-83
-        index = code - 48;
-    if ( code >= KEY_F11 && code <= KEY_F12 )  // 87-88
-        index = code - 51;
-    if ( code >= KEY_KPENTER && code <= KEY_DELETE )  // 96-111
-        index = code - 58;
-    if ( code == KEY_PAUSE )  // 119
-        index = code - 65;
-    if ( code >= KEY_LEFTMETA && code <= KEY_COMPOSE )  // 125-127
-        index = code - 70;
-    return index;
 }
 
 uint8_t hemiola::KeyTable::scanToHex ( unsigned int code ) const
@@ -204,10 +159,10 @@ uint8_t hemiola::KeyTable::modToHex ( unsigned int code ) const
     }
 }
 
-// std::optional<wchar_t> hemiola::KeyTable::handleScanCode ( unsigned int code, const KeyState&
+// std::optional<char> hemiola::KeyTable::handleScanCode ( unsigned int code, const KeyState&
 // keyState ) const
 // {
-//     std::optional<wchar_t> wch;
+//     std::optional<char> wch;
 //     if ( isCharKey ( code ) ) {
 //         if ( keyState.altgr ) {
 //             wch = altgrKeys ( code );

--- a/src/KeyboardEvents.cpp
+++ b/src/KeyboardEvents.cpp
@@ -118,6 +118,7 @@ bool hemiola::KeyboardEvents::updateKeyState()
              && m_KeyReport.keys [2] != scanHex && m_KeyReport.keys [3] != scanHex
              && m_KeyReport.keys [4] != scanHex && m_KeyReport.keys [5] != scanHex ) {
             // add current key press to the list of key presses, and don't overwrite
+            // TODO: handle KEY_ERR_OVF
             for ( auto& code : m_KeyReport.keys ) {
                 if ( code == 0x00 ) {
                     code = scanHex;


### PR DESCRIPTION
Switched to pure `std::string`s instead of `std::wstring` and `char` instead of `wchar_t`. This limits us to mostly english text, but we will figure out the details of non-english characters later.